### PR TITLE
Offer a shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "bin": {
     "bake-component": "bin/bake-component",
-    "bakec": "bin/bake-component
+    "bake": "bin/bake-component"
   },
   "scripts": {
     "start": "node bin/bake-component",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "bake-component CLI",
   "private": true,
   "bin": {
-    "bake-component": "bin/bake-component"
+    "bake-component": "bin/bake-component",
+    "bakec": "bin/bake-component
   },
   "scripts": {
     "start": "node bin/bake-component",


### PR DESCRIPTION
`bake-component` is pretty long and prone to typos. This PR adds another command: `bake` which does the same thing

This might cause conflicts with [other packages called bake like [all of these npm ones](https://github.com/search?q=filename%3Apackage.json+bin+bake) or [cakephp folks](https://book.cakephp.org/3.0/en/bake/usage.html) , idk if that matters 🤷‍♂️ 

Other are some other alternatives if the : `bakec`, `compo`, `bc`