### PR TITLE
Remove unneeded Component import.

### DIFF
--- a/src/templates/functional.js.ejs
+++ b/src/templates/functional.js.ejs
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 const <%= props.name %> = (props) => {
     return <p>Welcome</p>


### PR DESCRIPTION
As this template creates an SFC, there is no need to extend the Component class.